### PR TITLE
Refactor plot code & split Remove button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 .RData
 .Rproj.user
 .httr-oauth
-droptoken.rds
+Rprof.out

--- a/R/peds-builtin.R
+++ b/R/peds-builtin.R
@@ -72,6 +72,7 @@ swpSx = function(x, ids)
 
 
 BUILTIN_PEDS = list(
+  "Singleton" = singleton(1),
   "Trio" = nuclearPed(1),
   "Full siblings" = nuclearPed(2, sex = 1:2),
   "Half siblings (mat)" = halfSibPed(1, 1, sex2 = 2, type = "maternal"),
@@ -127,6 +128,7 @@ paramsBuiltin = function(choice) {
 BUILTIN_CHOICES = list(
   Choose = "",
   `Basic pedigrees` = list(
+    "Singleton",
     "Trio",
     "Full siblings",
     "Half siblings (mat)",

--- a/R/plot-utils.R
+++ b/R/plot-utils.R
@@ -1,76 +1,33 @@
 
-# Main pedigree plot function
-plotPed = function(pedData, plotargs, selected = NULL, addBox = FALSE) {
-  dat = tryCatch(
-    plot(pedData$ped,
-         aff        = pedData$aff,
-         carrier    = pedData$carrier,
-         deceased   = pedData$deceased,
-         twins      = pedData$twins,
-         col        = list(red = selected),
-         labs       = switch(plotargs$showlabs, show = breakLabs, hide = NULL),
-         cex        = plotargs$cex,
-         symbolsize = plotargs$symbolsize,
-         margins    = plotargs$mar),
-    error = function(e) {
-      msg = conditionMessage(e)
-      if(grepl("reduce cex", msg))
-        msg = "Plot region is too small"
-      stop(msg)
-    }
-  )
-
-  if(addBox)
-    box("outer", col = 1)
-
-  # Return plot object for storage
-  dat
-}
-
-
-# Current plot labels in the order plotted
-getPlotOrder = function(ped, plist, perGeneration = FALSE) {
-
-  # Index of each indiv, listed by generation
-  idxList = lapply(seq_along(plist$n), function(i) plist$nid[i, 1:plist$n[i]])
-
-  # Check for dups
-  dups = duplicated(unlist(idxList))
-
-  if(any(dups)) {
-    # Generation number of each (used to remove dups)
-    g = rep(seq_along(plist$n), plist$n)
-
-    # Reduce
-    g2 = g[!dups]
-
-    # Create new idxList
-    idxList = split(unlist(idxList)[!dups], unlist(g2))
-  }
-
-  if(perGeneration)
-    lapply(idxList, function(v) labels(ped)[v])
-  else
-    labels(ped)[unlist(idxList)]
-}
-
 
 # Prepare data for updating labels in plot
-updateLabelsData = function(currData, old, new, reorder = FALSE) {
+updateLabelsData = function(currData, old = NULL, new, .alignment = NULL) {
+  ped = currData$ped
+  reorder = FALSE
+
+  # If new = "asPlot" or "generations" (hack needed since pedigree is always reordered)
+  if(is.null(old)) {
+    idMap = relabel(ped, old = NULL, new = new, .alignment = .alignment, returnLabs = TRUE)
+    newped = relabel(ped, old = names(idMap), new = idMap, reorder = TRUE)
+  }
+  else {
+    newped = relabel(ped, old = old, new = new, reorder = FALSE)
+    idMap = setNames(newped$ID, ped$ID)
+  }
 
   newtw = currData$twins
-  newtw$id1 = new[match(newtw$id1, old)]
-  newtw$id2 = new[match(newtw$id2, old)]
+  newtw$id1 = idMap[newtw$id1]
+  newtw$id2 = idMap[newtw$id2]
 
-  list(ped = relabel(currData$ped, old = old, new = new, reorder = reorder),
-       aff = new[match(currData$aff, old)],
-       carrier = new[match(currData$carrier, old)],
-       deceased = new[match(currData$deceased, old)],
+  list(ped = newped,
+       aff = idMap[currData$aff],
+       carrier = idMap[currData$carrier],
+       deceased = idMap[currData$deceased],
        twins = newtw)
 }
 
 breakLabs = function(x, breakAt = "  ") {
-  labs = labels(x)
+  labs = x$ID
   names(labs) = gsub(breakAt, "\n", labs)
   labs
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -16,7 +16,14 @@ bold = function(x) strong(x, .noWS = "outside")
 ital = function(x) em(x, .noWS = "outside")
 
 errModal = function(..., html = FALSE) {
-  mess = paste(lapply(list(...), toString), collapse = "")
+  args = list(...)
+  if(length(args) == 1 && inherits(args, "condition")) {
+    mess = conditionMessage(args[[1]])
+    if(grepl("reduce cex", mess))
+      mess = "Plot region is too small"
+  }
+  else
+    mess = paste(lapply(args, toString), collapse = "")
   if(html)
     mess = HTML(mess)
   showModal(modalDialog(mess, easyClose = TRUE))

--- a/R/utils.R
+++ b/R/utils.R
@@ -124,23 +124,6 @@ addSib = function(x, id, sex) {
   return(newped)
 }
 
-pdat2df = function(pdat) {
-  n = pdat$plist$n
-  nid = pdat$plist$nid
-  pos = pdat$plist$pos
-
-  # Coordinates of top point of each symbol
-  x = unlist(lapply(seq_along(n), function(i) pos[i, 1:n[i]]))
-  y = rep(seq_along(n), n)
-
-  # Adjust y to give symbol centre
-  y = y + pdat$boxh/2
-
-  # Internal ID
-  idInt = unlist(lapply(seq_along(n), function(i) nid[i, 1:n[i]]))
-
-  data.frame(x = x, y = y, idInt = idInt)
-}
 
 
 sortIds = function(x, ids) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -90,6 +90,10 @@ updateTwins = function(twins, ids, code) {
   twins
 }
 
+hasMZtwins = function(currData) {
+  code = currData$twins$code
+  length(code) > 0 && 1 %in% code
+}
 
 addChild = function(x, id, sex) {
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -6,6 +6,9 @@ stop2 = function (...) {
   do.call(stop, a)
 }
 
+.myintersect = function(x, y)
+  y[match(x, y, 0L)]
+
 bigHeading = function(x)
   h4(strong(x), .noWS = "before")
 
@@ -132,6 +135,32 @@ addSib = function(x, id, sex) {
 }
 
 
+removeSel = function(currData, ids, updown) {
+  newped = tryCatch(
+    removeIndividuals(currData$ped, ids, remove = updown, verbose = FALSE),
+    error = function(e) conditionMessage(e)
+  )
+
+  isEmpty = is.null(newped)
+  discon = is.character(newped) && grepl("disconnected", newped, ignore.case = TRUE)
+
+  errmsg = if(is.character(newped)) newped else NULL
+  if(isEmpty || discon)
+    errmsg = sprintf("Removing %s would leave a disconnected or empty pedigree",
+                     ifelse(length(ids) == 1, paste("individual", ids), "these individuals"))
+  if(!is.null(errmsg))
+    stop2(errmsg)
+
+  newID = newped$ID
+  newaff  = .myintersect(currData$aff, newID)
+  newcarr = .myintersect(currData$carrier, newID)
+  newdec  = .myintersect(currData$deceased, newID)
+
+  newtw = currData$twins
+  newtw = newtw[newtw$id1 %in% newID & newtw$id2 %in% newID, , drop = FALSE]
+
+  list(ped = newped, aff = newaff, carr = newcarr, dec = newdec, tw = newtw)
+}
 
 sortIds = function(x, ids) {
   intern = internalID(x, ids)

--- a/app.R
+++ b/app.R
@@ -2,7 +2,6 @@ suppressPackageStartupMessages({
   library(shiny)
   library(shinyBS)
   library(shinyjs)
-  library(kinship2)
   library(pedtools)
   library(ribd)
   library(verbalisr)

--- a/app.R
+++ b/app.R
@@ -285,10 +285,7 @@ server = function(input, output, session) {
 
   observeEvent(input$loadped, {
     file = req(input$loadped$datapath)
-    y = tryCatch(readPed2(file),
-      error = function(e) errModal(conditionMessage(e)),
-      warning = function(e) errModal(conditionMessage(e))
-    )
+    y = tryCatch(readPed2(file), error = errModal, warning = errModal)
 
     updatePedData(currentPedData(), ped = req(y$ped), aff = y$aff, carrier = character(0), deceased = character(0),
                   twins = data.frame(id1 = character(0), id2 = character(0), code = integer(0)))
@@ -296,7 +293,6 @@ server = function(input, output, session) {
 
 
 # Modify pedigree ---------------------------------------------------------
-
 
   observeEvent(input$addson, {
     id = req(sel())

--- a/app.R
+++ b/app.R
@@ -113,13 +113,16 @@ ui = fluidPage(
             midHeading("Remove"),
             fluidRow(
               column(6, align = "left", style = "padding-right: 3px;",
-                     fluidRow(
-                       column(6, style = "padding-right: 3px;",
-                              actionButton("removeDown", icon("arrow-down"), width = "100%",style = "padding-top: 5px; padding-bottom: 5px; padding-left: 0px; padding-right: 0px")),
-                       column(6, style = "padding-left: 3px;",
-                              actionButton("removeUp", icon("arrow-up"), width = "100%",style = "padding-top: 5px; padding-bottom: 5px; padding-left: 0px; padding-right: 0px")),
-                     )),
+                fluidRow(
+                  column(6, style = "padding-right: 3px;",
+                         actionButton("removeDown", icon("arrow-down"), width = "100%",style = "padding-top: 5px; padding-bottom: 5px; padding-left: 0px; padding-right: 0px")),
+                  column(6, style = "padding-left: 3px;",
+                         actionButton("removeUp", icon("arrow-up"), width = "100%",style = "padding-top: 5px; padding-bottom: 5px; padding-left: 0px; padding-right: 0px")),
+               )),
               pedButton("clearselection", "Deselect", side = "right"),
+              bsTooltip("removeDown", HTML("Remove&nbsp;selected + descendants"), placement = "top"),
+              bsTooltip("removeUp", HTML("Remove&nbsp;selected + ancestors"), placement = "top"),
+              bsTooltip("clearselection", "Deselect all", placement = "top"),
             ),
             disabled(actionButton("undo", "Undo", class = "btn btn-warning",
                                   style = "position: absolute; bottom:30px; width: 170px")),

--- a/app.R
+++ b/app.R
@@ -120,7 +120,7 @@ ui = fluidPage(
                        column(6, style = "padding-left: 3px;",
                               actionButton("removeUp", icon("arrow-up"), width = "100%",style = "padding-top: 5px; padding-bottom: 5px; padding-left: 0px; padding-right: 0px")),
                      )),
-              pedButton("clearselection", "Deselect all", side = "right"),
+              pedButton("clearselection", "Deselect", side = "right"),
             ),
             disabled(actionButton("undo", "Undo", class = "btn btn-warning",
                                   style = "position: absolute; bottom:30px; width: 170px")),

--- a/app.R
+++ b/app.R
@@ -546,24 +546,24 @@ server = function(input, output, session) {
 
   # Plot --------------------------------------------------------------------
 
-  plotLabs = reactive({ print("labs")
+  plotLabs = reactive({ #print("labs")
     ped = req(currentPedData()$ped)
     switch(input$showlabs, show = breakLabs(ped), hide = NULL)
   })
 
-  plotAlignment = reactive({ print("align")
+  plotAlignment = reactive({ #print("align")
     curr = currentPedData()
     .pedAlignment(curr$ped, twins = curr$twins)
   })
 
-  plotAnnotation = reactive({ print("annot")
+  plotAnnotation = reactive({ #print("annot")
     curr = req(currentPedData())
     labs = plotLabs()
     .pedAnnotation(curr$ped, labs = labs, aff = curr$aff, carrier = curr$carrier,
                    deceased = curr$deceased, col = list(red = sel()))
   })
 
-  plotScaling = reactive({ print("scaling")
+  plotScaling = reactive({ #print("scaling")
     input$width; input$height # react to these also
     align = req(plotAlignment())
     annot = list(textUnder = plotLabs())

--- a/app.R
+++ b/app.R
@@ -330,7 +330,7 @@ server = function(input, output, session) {
     id = req(sel())
     currData = currentPedData()
     newped = tryCatch(addParents(currData$ped, id, verbose = FALSE),
-                      error = function(e) errModal(e))
+                      error = errModal)
     updatePedData(currData, ped = newped)
   })
 
@@ -707,12 +707,19 @@ server = function(input, output, session) {
   )
 
   observeEvent(input$coeffTable, {
-    ped = currentPedData()$ped
+    currData = currentPedData()
+    ped = currData$ped
     ids = sel()
+
+    if(hasMZtwins(currData)) {
+      relText("This feature does not support MZ twin pedigrees.")
+      return()
+    }
+
     if(!length(ids))
       ids = labels(ped)
     updateTextInput(session, "coeffIds", value = toString(sortIds(ped, ids)))
-    tryCatch(showModal(dlg), error = function(e) errModal(conditionMessage(e)))
+    tryCatch(showModal(dlg), error = errModal)
   })
 
 
@@ -747,8 +754,7 @@ server = function(input, output, session) {
         # Close window
         removeModal()
       },
-        error = function(e) errModal(conditionMessage(e))
-      )
+      error = errModal)
     }
   )
 
@@ -757,11 +763,17 @@ server = function(input, output, session) {
   kappa = reactiveVal(NULL)
 
   observeEvent(input$triangle, {
-    ped = currentPedData()$ped
+    currData = currentPedData()
+    ped = currData$ped
     ids = sortIds(ped, ids = sel())
 
     if(length(ids) != 2) {
       relText("Please select exactly 2 individuals.")
+      return()
+    }
+
+    if(hasMZtwins(currData)) {
+      relText("This feature does not support MZ twin pedigrees.")
       return()
     }
 
@@ -804,11 +816,17 @@ server = function(input, output, session) {
   )
 
   observeEvent(input$describe, {
-    ped = req(currentPedData()$ped)
+    currData = currentPedData()
+    ped = req(currData$ped)
     ids = sortIds(ped, ids = sel())
 
     if(length(ids) != 2) {
       relText("Please select exactly 2 individuals.")
+      return()
+    }
+
+    if(hasMZtwins(currData)) {
+      relText("This feature does not support MZ twin pedigrees.")
       return()
     }
 
@@ -821,13 +839,19 @@ server = function(input, output, session) {
 
 
   observeEvent(input$coeffs, {
-    ped = req(currentPedData()$ped)
+    currData = currentPedData()
+    ped = req(currData$ped)
     ids = sortIds(ped, ids = sel())
 
     N = length(ids)
     if(!N %in% 1:2) {
       relText(c("Please select 1 or 2 individuals.",
                 "(Or click the Table button for more options.)"))
+      return()
+    }
+
+    if(hasMZtwins(currData)) {
+      relText("This feature does not support MZ twin pedigrees.")
       return()
     }
 


### PR DESCRIPTION
Rewriting much of the plotting code to sync with the latest changes in **pedtools** (should give faster and more responsive plots). 

The button for removing individuals is relocated and split in two : 
* down (remove selected individuals and their descendants)
* up (remove selected and their ancestors)